### PR TITLE
Pausing game when it loses visibility

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,3 @@
+linter:
+  rules:
+    avoid_web_libraries_in_flutter: false

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flame/flame.dart';
 
 import 'dart:math';
+import 'dart:html';
 
 import './dextra_quario.dart';
 import './components/fish.dart';
@@ -20,6 +21,14 @@ void main() async {
       0,
       (value, current) => max(value, current.fishItems.length),
   );
+
+  window.addEventListener('visibilitychange', (Event event) {
+    if (window.document.visibilityState == 'visible') {
+      game.resumeEngine();
+    } else {
+      game.pauseEngine();
+    }
+  });
 
   fishes.forEach((fishInfo) {
     game.add(


### PR DESCRIPTION
When the game loses visibility (aka, tab loses focus, or browser window is minimized) the game was not been paused, which could accumulate a bunch o render cycles to be executed all at once once the visibility was regain, which would leave the game on an invalid state.

This PR fixes that.