### PR TITLE
Better fish label UI

### DIFF
--- a/lib/components/fish.dart
+++ b/lib/components/fish.dart
@@ -53,8 +53,7 @@ class Fish extends PositionComponent with HasGameRef<DextraQuario> {
 
     final label = "${fishInfo.name} (${fishInfo.fishItems.length})";
     _labelTp = _nameLabel.toTextPainter(label);
-    // Flame has a little bug creating textPainter with the same text
-    _focusedLabelTp = _focusedNameLabel.toTextPainter(" $label ");
+    _focusedLabelTp = _focusedNameLabel.toTextPainter(label);
   }
 
   void setTarget(Position target) {

--- a/lib/dextra_quario.dart
+++ b/lib/dextra_quario.dart
@@ -19,6 +19,8 @@ class DextraQuario extends BaseGame with HasWidgetsOverlay, TapDetector {
   double _scaleFactor;
   Position _translateFactor;
 
+  Offset mousePos;
+
   DextraQuario(Size screenSize) {
     this.size = screenSize;
     _calcScaleFactor();
@@ -65,13 +67,21 @@ class DextraQuario extends BaseGame with HasWidgetsOverlay, TapDetector {
     super.render(canvas);
   }
 
+  Offset _projectOffset(Offset offset) {
+    return Offset(
+        (offset.dx - _translateFactor.x) / _scaleFactor,
+        (offset.dy - _translateFactor.y) / _scaleFactor,
+    );
+  }
+
+  void updateMouse(Offset offset) {
+    mousePos = _projectOffset(offset);
+  }
+
   @override
   void onTapUp(details) {
 
-    final projectedOffset = Offset(
-        (details.localPosition.dx - _translateFactor.x) / _scaleFactor,
-        (details.localPosition.dy - _translateFactor.y) / _scaleFactor,
-    );
+    final projectedOffset = _projectOffset(details.localPosition);
 
     List<Fish> fishes() => components.where((c) => c is Fish).cast<Fish>().toList();
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,7 +32,12 @@ void main() async {
 
   runApp(MaterialApp(
     home: Scaffold(
-      body: game.widget,
+      body: MouseRegion(
+          child: game.widget,
+          onHover: (event) {
+            game.updateMouse(event.localPosition);
+          },
+      ),
     ),
   ));
 }


### PR DESCRIPTION
Given the number of fishes on the aquarium, it was quite hard to read all the names.

This PR proposes an improvement on this.

Now the labels stays transparent and small, and upon a mouse hover, the label becomes opaque and bigger.

![mousehover](https://user-images.githubusercontent.com/835641/92667782-40fc5c80-f2e3-11ea-8caa-14c6aff60167.gif)
