### PR TITLE
Adding boundaries on the fish target

### DIFF
--- a/lib/components/fish.dart
+++ b/lib/components/fish.dart
@@ -56,8 +56,18 @@ class Fish extends PositionComponent with HasGameRef<DextraQuario> {
     _focusedLabelTp = _focusedNameLabel.toTextPainter(label);
   }
 
+  Position _trimTarget(Position target) {
+    final maxX = DextraQuario.GAME_WIDTH - width;
+    final maxY = DextraQuario.GAME_HEIGHT - height;
+
+    return Position(
+        max(0.0, min(maxX, target.x)),
+        max(0.0, min(maxY, target.y)),
+    );
+  }
+
   void setTarget(Position target) {
-    _target = target;
+    _target = _trimTarget(target);
     _runningForFood = true;
   }
 


### PR DESCRIPTION
Fishes could swim our of the game boundaries when a target was generated by a click, this PR fixes that.
![fish-boundaries](https://user-images.githubusercontent.com/835641/92804750-ee787a00-f38e-11ea-91c5-0e50cb0afd26.gif)
